### PR TITLE
Add monitoring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: "Publish gem"
+on:
+  push:
+    tags:
+      - 'v**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install --path vendor/bundle --jobs 4 --retry 3
+
+      - name: Publish to RubyGems Packages
+        env:
+          GEM_HOST_API_KEY: ${{secrets.GEM_HOST_API_KEY}}
+        run: |
+          gem build ruby_pipeline.gemspec
+          gem push ruby_pipeline-*.gem

--- a/README.md
+++ b/README.md
@@ -72,3 +72,15 @@ We're using RSpec for testing. Run the test suite with rake spec. Tests for pull
 ## License
 
 `ruby-pipeine`` is free software released under the MIT License. See LICENSE for details.
+
+## Publishing a gem version
+
+This gem uses Github Packages Registry to store gems, and all builds get pushed to it.
+
+    Update lib/brokkr/version.rb with the new version
+    Create and push a tag:
+
+git tag 'v0.1.0' # replace with your version
+git push origin 'v0.1.0'
+
+This will automatically trigger the release workflow of GHA, after which you will be able to install a fresh version of a gem into your system.

--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ We're using RSpec for testing. Run the test suite with rake spec. Tests for pull
 
 This gem uses Github Packages Registry to store gems, and all builds get pushed to it.
 
-    Update lib/brokkr/version.rb with the new version
-    Create and push a tag:
+1. Update `lib/ruby_pipeline/version.rb` with the new version
+2. Create and push a tag:
 
-git tag 'v0.1.0' # replace with your version
-git push origin 'v0.1.0'
+  ```bash
+    git tag 'v0.1.0' # replace with your version
+    git push origin 'v0.1.0'
+  ```
 
 This will automatically trigger the release workflow of GHA, after which you will be able to install a fresh version of a gem into your system.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ end
 MyPipeline.new.process(data)
 ```
 
+### Config
+
+You can configure a success callback to be called after each step is processed:
+
+```ruby
+RubyPipeline.configure do |config|
+  config.success_callback = ->(step) { my_monitoring_service.notify(step) }
+  config.failure_callback = ->(step) { puts "Failure in step #{step}" }
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/ruby_pipeline.rb
+++ b/lib/ruby_pipeline.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 require 'ruby_pipeline/version'
+require 'ruby_pipeline/configuration'
 require 'ruby_pipeline/base_pipeline'
 
 module RubyPipeline
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
+    end
+  end
 end

--- a/lib/ruby_pipeline/base_pipeline.rb
+++ b/lib/ruby_pipeline/base_pipeline.rb
@@ -10,8 +10,9 @@ module RubyPipeline
       steps.inject(input) do |memo, step|
         step_result = step.process(memo)
 
-        break false if step_result.nil?
+        break failure(step) if step_result.nil?
 
+        success(step)
         step_result
       end
     end
@@ -21,5 +22,12 @@ module RubyPipeline
     attr_reader :steps
 
     def default_steps = []
+
+    def success(step) = RubyPipeline.configuration.success_callback.call(step)
+
+    def failure(step)
+      RubyPipeline.configuration.failure_callback.call(step)
+      false
+    end
   end
 end

--- a/lib/ruby_pipeline/configuration.rb
+++ b/lib/ruby_pipeline/configuration.rb
@@ -5,8 +5,8 @@ module RubyPipeline
     attr_accessor :success_callback, :failure_callback
 
     def initialize
-      @success_callback = ->(step) { puts "Success in step #{step}" }
-      @failure_callback = ->(step) { puts "Failure in step #{step}" }
+      @success_callback = ->(step) {}
+      @failure_callback = ->(step) {}
     end
   end
 end

--- a/lib/ruby_pipeline/configuration.rb
+++ b/lib/ruby_pipeline/configuration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RubyPipeline
+  class Configuration
+    attr_accessor :success_callback, :failure_callback
+
+    def initialize
+      @success_callback = ->(step) { puts "Success in step #{step}" }
+      @failure_callback = ->(step) { puts "Failure in step #{step}" }
+    end
+  end
+end


### PR DESCRIPTION
When the gem is used, the user might want to use instrumentation on success/failures of the steps.
Without knowing what they are using, we can use callbacks that the user then sets in the config block.
